### PR TITLE
Update articleAPA_min.tex

### DIFF
--- a/articleAPA_min/articleAPA_min.tex
+++ b/articleAPA_min/articleAPA_min.tex
@@ -3,6 +3,7 @@
 % LATEX packages packages
 \usepackage[style=apa, backend=biber]{biblatex}
 \usepackage[american]{babel}
+\usepackage{ragged2e}
 \DeclareLanguageMapping{american}{american-apa}
 
 \addbibresource{bibfile.bib}
@@ -28,6 +29,7 @@
 
 \begin{document}
 \maketitle
+\justifying
 The introduction .. \textcite{botvinick2001conflict}
 
 \textcite{botvinick2001conflict} found that .. \\


### PR DESCRIPTION
somehow the document seems to be flush left.
I propose to use ragged2e and \justifying to fix that. \justify has to be placed after \maketitle to work.  I suppose it is the root cause of the issue.